### PR TITLE
feature: pattern guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ The syntax follow Perl's syntax:
 
 ## Limitations
 
-### No Pattern Guards
+### No Pattern Guards for `ppx_tyre`
 
-Pattern guards are not supported.  This is due to the fact that all match
-cases are combined into a single regular expression, so if one of the
-patterns succeed, the match is committed before we can check the guard
-condition.
+Pattern guards are not supported in `ppx_tyre`. This is due to the fact that all match
+cases are combined into a single regular expression, so if one of the patterns succeed,
+the match is committed before we can check the guard condition.
+
+`ppx_regexp` does support pattern guards by grouping cases with identical patterns
+and generating monadic handler functions that evaluate guards sequentially after a pattern matches.
 
 ### No Exhaustiveness Check
 

--- a/ppx_regexp.opam
+++ b/ppx_regexp.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.11"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & <= "0.35.0"}
   "re" {>= "1.7.2"}
   "qcheck" {with-test}
 ]


### PR DESCRIPTION
Related to #12 

This PR adds support for pattern guards. The scope for the guards contains the variables bound by the regexes.

### Details

This feature changes the generated code the most. 

**Before:** Each pattern case generated inline matching code:
```ocaml
match Re.exec_opt (fst _ppx_regexp_1) _ppx_regexp_v with
  | None -> default_rhs
  | Some _g ->
      if Re.Mark.test _g marks.(0) then
        let x = Re.Group.get _g 1 in
        ...
      else if Re.Mark.test _g marks.(1) then
        ...
      else
        assert false
```

**After:** Pattern cases are compiled into handler functions that return option values:
```ocaml
match Re.exec_opt (fst _ppx_regexp_1) _ppx_regexp_v with
  | None -> default_rhs
  | Some _g ->
      let _case_0 _g =
        (* RE bindings are put here *)
        let x = Re.Group.get _g 1 in
        (* potential guard checks here, for example *)
        if int_of_string x > 100 then Some (`Large x)
        else if int_of_string x > 10 then Some (`Medium x)
        else Some (`Small x)
      in
      let _case_1 _g = ... in
      ...
      let _case_n _g = ... in
      match
        if Re.Mark.test _g marks.(0) then _case_0 _g
        else if Re.Mark.test _g marks.(1) then _case_1 _g
        ...
        else if Re.Mark.test _g marks.(1) then _case_n _g
        else None
      with
      | Some result -> result
      | None -> default_rhs
```
Cases with the same pattern but different guards are grouped together.

## Note

This updates the opam package to use `ppxlib <= "0.35.0"` only, as `ppxlib.0.36.0` has breaking changes in the Parsetree AST.