### PR TITLE
feature: variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ into suitable invocations of the [Re library][re], and similar for
     the whole pattern matches, and `string option` if the variable is bound
     to or nested below an optionally matched group.
 
+  - `(?&<var>)` gets substituted by the value of the `%pcre` extended string variable named `var`. Doesn't bind.
+
+  - `(?&<v>:<qname>)` is a shortcut for `(?<v>(?&<qname>))`.
+
   - `?<var>` at the start of a pattern binds group 0 as `var : string`.
     This may not be the full string if the pattern is unanchored.
 

--- a/ppx_regexp.opam
+++ b/ppx_regexp.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.11"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & <= "0.35.0"}
   "re" {>= "1.7.2"}
   "qcheck" {with-test}
 ]


### PR DESCRIPTION
Related to #12 

This PR adds variable substitution to the `%pcre` extension.

### Details

Allows defining variables with `let%pcre`, which could then be used inside a few patterns for substitution:
- `(?&var)` - Named substitution (doesn't capture)
- `(?&name:var)` - Named substitution with rename

Only 1 AST pass is needed.

~~If a user tries to define `let%pcre var = (?N<var>)`, the ppx is smart enough to warn the user about having unbounded recursion.~~

## Note

This updates the opam package to use `ppxlib <= "0.35.0"` only, as `ppxlib.0.36.0` has breaking changes in the Parsetree AST.
