### PR TITLE
feature: case-insensitive match

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A variable is allowed for the universal case and is bound to the matched
 string.  A regular alias is currently not allowed for patterns, since it is
 not obvious whether is should bind the full string or group 0.
 
+### Case-Insensitive Match
+
+An extension, `%pcre_i`, is available for case-insensitive matching.
+
 ### Example
 
 The following prints out times and hosts for SMTP connections to the Postfix


### PR DESCRIPTION
Related to #12 

This PR adds a new extension, `%pcre_i`, for case-insensitive match.

## Note

This updates the opam package to use `ppxlib <= "0.35.0"` only, as `ppxlib.0.36.0` has breaking changes in the Parsetree AST.