### PR TITLE
Fix compatibility with ppxlib >= 0.36 and OCaml 4.11-5.5.

### DIFF
--- a/common/regexp.ml
+++ b/common/regexp.ml
@@ -108,19 +108,28 @@ let parse_exn ?(pos = Lexing.dummy_pos) s =
      | 'A'..'Z' | 'a'..'z' | '_' -> scan_cont (i + 1)
      | _ -> fail (i, i) "Expecting an identifier.")
   in
-  let rec scan_longident_cont lidr i =
-    if get i <> '.' then (i, lidr) else
+  let rec scan_longident_parts parts i =
+    if get i <> '.' then (i, List.rev parts) else
     let j, idr = scan_ident (i + 1) in
-    scan_longident_cont (Longident.Ldot (lidr, idr)) j
+    scan_longident_parts (idr :: parts) j
+  in
+  let build_longident parts =
+    match Longident.unflatten parts with
+    | Some lid -> lid
+    | None -> assert false  (* parts is always non-empty *)
   in
   let scan_longident i =
     let j, idr = scan_ident i in
-    scan_longident_cont (Longident.Lident idr) j
+    let k, parts = scan_longident_parts [idr] j in
+    (k, build_longident parts)
   in
   let scan_ident = with_loc scan_ident in
   let scan_longident = with_loc scan_longident in
   let scan_longident_cont idr =
-    with_loc (scan_longident_cont (Longident.Lident idr)) in
+    with_loc (fun i ->
+      let j, parts = scan_longident_parts [idr] i in
+      (j, build_longident parts))
+  in
 
   (* Non-Nested Parts *)
   let re_perl (i, j) =

--- a/ppx_regexp.opam
+++ b/ppx_regexp.opam
@@ -8,13 +8,13 @@ license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
 homepage: "https://github.com/paurkedal/ppx_regexp"
 bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
-  "dune" {>= "1.11"}
-  "ppxlib" {>= "0.9.0"}
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "3.10.0"}
+  "ppxlib" {>= "0.36.0"}
   "re" {>= "1.7.2"}
-  "qcheck" {with-test}
+  "qcheck" {with-test & >= "0.90"}
 ]
-build: ["dune" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
 dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
 synopsis: "Matching Regular Expressions with OCaml Patterns"
 description: """

--- a/ppx_regexp/ppx_regexp.ml
+++ b/ppx_regexp/ppx_regexp.ml
@@ -214,7 +214,7 @@ let transformation = object
          | Pexp_match (e, cases) ->
             let cases, binding = transform_cases ~loc cases in
             ([%expr let _ppx_regexp_v = [%e e] in [%e cases]], binding :: acc)
-         | Pexp_function (cases) ->
+         | Pexp_function ([], None, Pfunction_cases (cases, _, _)) ->
             let cases, binding = transform_cases ~loc cases in
             ([%expr fun _ppx_regexp_v -> [%e cases]], binding :: acc)
          | _ ->

--- a/tests/test_regexp.ml
+++ b/tests/test_regexp.ml
@@ -216,7 +216,7 @@ let gen_name =
   in
   let idrfst = map idrletter (int_bound (27 - 1)) in
   let idrcnt = map idrletter (int_bound (63 - 1)) in
-  map2 (fun c s -> String.make 1 c ^ s) idrfst (string ~gen:idrcnt)
+  map2 (fun c s -> String.make 1 c ^ s) idrfst (string_of idrcnt)
 
 let gen_regexp =
   let open Q.Gen in
@@ -246,7 +246,7 @@ let gen_regexp =
       map (fun e -> mknoloc (Capture e)) (self n) in
     let gen_capture_as =
       map2 (fun a e -> mknoloc (Capture_as (mknoloc a, e))) gen_name (self n) in
-    frequency [
+    oneof_weighted [
       1, gen_char;
       1, gen_backlash_op;
       1, gen_quoted_op;
@@ -323,7 +323,7 @@ let tests = [
           Q.Test.fail_reportf "%a" pp_location_error err
        | e' -> Regexp.equal e' e));
   Q.Test.make ~long_factor:100 ~name:"to_string ∘ parse"
-    (Q.string_gen Q.Gen.printable) test_parse;
+    (Q.string_of Q.Gen.printable) test_parse;
 ]
 
 let () = QCheck_runner.run_tests_main tests


### PR DESCRIPTION
Three compatibility fixes:

ppxlib 0.36.0 changed its internal AST from OCaml 4.14 to OCaml 5.2's AST, which wound up being a simple change in ppx_regexp.ml to the match on Pexp_function.

OCaml 5.4.x changed Longident.Ldot, and the simplest way to adapt to it was to use Longident.unflatten, which is stable. That change is in common/regexp.ml.

test_regexp.ml also needed updates for a QCheck API change (string ~gen: -> string_of, frequency -> oneof_weighted).

Update the opam file to include the bounds found by an invocation of opam-minver: those are the tested minimum bounds. OCaml 4.11.0 is earliest compiler installable with opam.